### PR TITLE
Errors of "du" can be safely ignored

### DIFF
--- a/lib/FileManager/workers/local/analyzeSize.py
+++ b/lib/FileManager/workers/local/analyzeSize.py
@@ -41,7 +41,7 @@ class AnalyzeSize(BaseWorkerCustomer):
                 du_regex = re.compile('^([0-9]+)\s+(.*)$', re.UNICODE | re.IGNORECASE)
 
                 p = SubprocessRunner(command=command, logger=self.logger, stdout=subprocess.PIPE,
-                                     stderr=subprocess.PIPE)
+                                     stderr=subprocess.DEVNULL)
 
                 for line in p.iterate():
                     try:


### PR DESCRIPTION
Утилита `du` генерирует ошибки, если у неё нет доступа к файлам или директориям.

Это приводит к тому, что если root положил хоть один служебный файл в директорию пользователя (например, конфиг nginx, который редактируется через панель управления хостинга), юзер уже не может подсчитать место в своей директории - всегда получает ошибку.
![2017-07-29 18 19 43](https://user-images.githubusercontent.com/1257284/28971771-e6926e58-7935-11e7-90ce-abdeece44315.png)


Думаю, ошибки `du` можно игнорировать, и выводить занимаемое место тех директорий, к которым у пользователя есть доступ.
![2017-07-29 18 19 53](https://user-images.githubusercontent.com/1257284/28971775-eb97e202-7935-11e7-9328-01e0f2ac2dd4.png)
